### PR TITLE
Reset check in page to 0 if reconstructing view

### DIFF
--- a/app/src/main/java/de/hbch/traewelling/ui/user/AbstractUserFragment.kt
+++ b/app/src/main/java/de/hbch/traewelling/ui/user/AbstractUserFragment.kt
@@ -60,6 +60,7 @@ abstract class AbstractUserFragment : Fragment() {
             }
         }
 
+        page = 1 // Reset page
         loadCheckIns()
 
         return binding.root


### PR DESCRIPTION
If you scroll to page >=2, select a checkin, that state will be saved, so you will then start requesting check ins starting at page "not 1"