### PR TITLE
🐛 Fixed non-working of app on Unauthorized errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'com.auth0.android:jwtdecode:2.0.1'
+    implementation 'org.greenrobot:eventbus:3.3.1'
 
     // OSM integration
     implementation 'org.osmdroid:osmdroid-android:6.1.10'

--- a/app/src/main/java/de/hbch/traewelling/api/ApiService.kt
+++ b/app/src/main/java/de/hbch/traewelling/api/ApiService.kt
@@ -27,7 +27,8 @@ private const val BASE_URL =
     "https://traewelling.de/api/v1/"
 
 private val client = OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS)
-    .addInterceptor(Interceptor() { chain ->
+    // Auth interceptor
+    .addInterceptor(Interceptor { chain ->
         val newRequest =
             chain
                 .request()
@@ -40,7 +41,18 @@ private val client = OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS)
                 .build()
 
         chain.proceed(newRequest)
-    }).build()
+    })
+    // Error interceptor
+    .addInterceptor(Interceptor { chain ->
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (response.code == 401)
+            TODO()
+
+        response
+    })
+    .build()
 
 private val gson = GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssX").create()
 
@@ -179,7 +191,7 @@ interface UserService {
 
 object TraewellingApi {
     var jwt: String = ""
-    var appVersion: String = ""
+
     val userService: UserService by lazy {
         retrofit.create(UserService::class.java)
     }

--- a/app/src/main/java/de/hbch/traewelling/api/ApiService.kt
+++ b/app/src/main/java/de/hbch/traewelling/api/ApiService.kt
@@ -1,7 +1,8 @@
 package de.hbch.traewelling.api
 
 import com.google.gson.GsonBuilder
-import de.hbch.traewelling.BuildConfig
+import de.hbch.traewelling.api.interceptors.AuthInterceptor
+import de.hbch.traewelling.api.interceptors.ErrorInterceptor
 import de.hbch.traewelling.api.models.Data
 import de.hbch.traewelling.api.models.auth.BearerToken
 import de.hbch.traewelling.api.models.auth.LoginCredentials
@@ -14,7 +15,6 @@ import de.hbch.traewelling.api.models.status.*
 import de.hbch.traewelling.api.models.trip.HafasTrainTrip
 import de.hbch.traewelling.api.models.trip.HafasTripPage
 import de.hbch.traewelling.api.models.user.User
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Call
 import retrofit2.Retrofit
@@ -27,31 +27,8 @@ private const val BASE_URL =
     "https://traewelling.de/api/v1/"
 
 private val client = OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS)
-    // Auth interceptor
-    .addInterceptor(Interceptor { chain ->
-        val newRequest =
-            chain
-                .request()
-                .newBuilder()
-                .addHeader("Authorization", "Bearer ${TraewellingApi.jwt}")
-                .addHeader(
-                    "User-Agent",
-                    "${BuildConfig.APPLICATION_ID}/${BuildConfig.VERSION_NAME}"
-                )
-                .build()
-
-        chain.proceed(newRequest)
-    })
-    // Error interceptor
-    .addInterceptor(Interceptor { chain ->
-        val request = chain.request()
-        val response = chain.proceed(request)
-
-        if (response.code == 401)
-            TODO()
-
-        response
-    })
+    .addInterceptor(AuthInterceptor())
+    .addInterceptor(ErrorInterceptor())
     .build()
 
 private val gson = GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssX").create()

--- a/app/src/main/java/de/hbch/traewelling/api/interceptors/AuthInterceptor.kt
+++ b/app/src/main/java/de/hbch/traewelling/api/interceptors/AuthInterceptor.kt
@@ -1,0 +1,23 @@
+package de.hbch.traewelling.api.interceptors
+
+import de.hbch.traewelling.BuildConfig
+import de.hbch.traewelling.api.TraewellingApi
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest =
+            chain
+                .request()
+                .newBuilder()
+                .addHeader("Authorization", "Bearer ${TraewellingApi.jwt}")
+                .addHeader(
+                    "User-Agent",
+                    "${BuildConfig.APPLICATION_ID}/${BuildConfig.VERSION_NAME}"
+                )
+                .build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/de/hbch/traewelling/api/interceptors/ErrorInterceptor.kt
+++ b/app/src/main/java/de/hbch/traewelling/api/interceptors/ErrorInterceptor.kt
@@ -1,0 +1,23 @@
+package de.hbch.traewelling.api.interceptors
+
+import de.hbch.traewelling.events.UnauthorizedEvent
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.greenrobot.eventbus.EventBus
+
+class ErrorInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (response.code == 401
+            /*TODO
+            * Following statement can be removed after https://github.com/Traewelling/traewelling/issues/1175
+            * is resolved.
+            * */
+            || (response.code == 200 && response.request.url.toUrl().path.contains("login")))
+            EventBus.getDefault().post(UnauthorizedEvent())
+
+        return response
+    }
+}

--- a/app/src/main/java/de/hbch/traewelling/events/UnauthorizedEvent.kt
+++ b/app/src/main/java/de/hbch/traewelling/events/UnauthorizedEvent.kt
@@ -1,5 +1,3 @@
 package de.hbch.traewelling.events
 
-class UnauthorizedEvent {
-
-}
+class UnauthorizedEvent

--- a/app/src/main/java/de/hbch/traewelling/events/UnauthorizedEvent.kt
+++ b/app/src/main/java/de/hbch/traewelling/events/UnauthorizedEvent.kt
@@ -1,0 +1,5 @@
+package de.hbch.traewelling.events
+
+class UnauthorizedEvent {
+
+}

--- a/app/src/main/java/de/hbch/traewelling/ui/main/MainActivity.kt
+++ b/app/src/main/java/de/hbch/traewelling/ui/main/MainActivity.kt
@@ -8,32 +8,26 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.provider.Settings
-import android.telecom.Call
-import android.view.WindowInsets
-import android.view.WindowInsets.Type.statusBars
 import android.view.WindowInsets.Type.systemBars
-import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI.setupWithNavController
 import androidx.navigation.ui.setupActionBarWithNavController
-import com.google.android.material.navigation.NavigationBarView
 import com.jcloquell.androidsecurestorage.SecureStorage
 import de.c1710.filemojicompat_ui.views.picker.EmojiPackItemAdapter
 import de.hbch.traewelling.R
 import de.hbch.traewelling.api.TraewellingApi
-import de.hbch.traewelling.api.models.Data
 import de.hbch.traewelling.databinding.ActivityMainBinding
-import de.hbch.traewelling.shared.LoggedInUserViewModel
+import de.hbch.traewelling.events.UnauthorizedEvent
 import de.hbch.traewelling.shared.SharedValues
-import io.sentry.Sentry
-import retrofit2.Callback
-import retrofit2.Response
+import de.hbch.traewelling.ui.login.LoginActivity
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 
 class MainActivity : AppCompatActivity() {
 
@@ -41,6 +35,29 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var secureStorage: SecureStorage
     lateinit var emojiPackItemAdapter: EmojiPackItemAdapter
+
+    override fun onStart() {
+        super.onStart()
+        EventBus.getDefault().register(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        EventBus.getDefault().unregister(this)
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onUnauthorizedEvent(unauthorizedEvent: UnauthorizedEvent) {
+        startActivity(
+            Intent(
+                this,
+                LoginActivity::class.java
+            )
+        )
+        secureStorage?.removeObject(SharedValues.SS_JWT)
+        TraewellingApi.jwt = ""
+        finish()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
This PR fixes #69 and adds
- interceptors for API Unauthorized errors
- an event bus which can be used in future for extended communication between components

When the API responds with 401 (or 200 with login page, true story), an event will be triggered and the user will be logged out in the app.