### PR TITLE
Improve Select Destination UI for multiline stops

### DIFF
--- a/app/src/main/res/layout/travel_stop_list_item.xml
+++ b/app/src/main/res/layout/travel_stop_list_item.xml
@@ -13,37 +13,43 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
         android:clickable="true"
-        android:focusable="true"
-        android:background="?android:attr/selectableItemBackground">
+        android:focusable="true">
+
         <ImageView
+            android:id="@+id/perlschnur_connection_top"
             android:layout_width="2dp"
-            android:layout_height="16dp"
+            android:layout_height="0dp"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_perlschnur_connection"
-            app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
+            app:layout_constraintBottom_toTopOf="@+id/perlschnur_stop"
             app:layout_constraintEnd_toEndOf="@id/perlschnur_stop"
+            app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
             app:layout_constraintTop_toTopOf="parent"
-            android:id="@+id/perlschnur_connection_top"
             app:tint="#8A8A8A" />
+
         <ImageView
+            android:id="@+id/perlschnur_stop"
+            style="@style/Theme.Traewelling.PrimaryColorIcons"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:id="@+id/perlschnur_stop"
-            android:src="@drawable/ic_perlschnur_main"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/perlschnur_connection_top"
             android:layout_marginStart="16dp"
-            style="@style/Theme.Traewelling.PrimaryColorIcons"  />
+            android:src="@drawable/ic_perlschnur_main"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <ImageView
+            android:id="@+id/perlschnur_connection_bottom"
             android:layout_width="2dp"
-            android:layout_height="16dp"
+            android:layout_height="0dp"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_perlschnur_connection"
-            app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/perlschnur_stop"
-            app:layout_constraintTop_toBottomOf="@id/perlschnur_stop"
-            android:id="@+id/perlschnur_connection_bottom"
+            app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
+            app:layout_constraintTop_toBottomOf="@+id/perlschnur_stop"
             app:tint="#8A8A8A" />
 
         <TextView
@@ -52,38 +58,42 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginEnd="12dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
             android:text="@{travelStop.name}"
             android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="@id/perlschnur_connection_bottom"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/text_view_destination_time"
             app:layout_constraintStart_toEndOf="@id/perlschnur_stop"
-            app:layout_constraintTop_toTopOf="@id/perlschnur_connection_top"
-            tools:text="Bad Grönenbach" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Test" />
 
         <LinearLayout
+            android:id="@+id/text_view_destination_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/text_view_destination_time"
-            app:layout_constraintTop_toTopOf="@id/perlschnur_connection_top"
+            android:layout_marginEnd="16dp"
             app:layout_constraintBottom_toBottomOf="@id/perlschnur_connection_bottom"
             app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginEnd="16dp">
+            app:layout_constraintTop_toTopOf="@id/perlschnur_connection_top">
+
             <TextView
+                android:id="@+id/destination_time"
+                displayTime="@{travelStop.arrivalReal ?? travelStop.arrivalPlanned}"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:id="@+id/destination_time"
-                tools:text="15:09"
-                displayTime="@{travelStop.arrivalReal ?? travelStop.arrivalPlanned}"
                 android:textSize="18sp"
                 android:visibility="@{travelStop.isCancelled ? View.GONE : View.VISIBLE}"
+                tools:text="15:09"
                 tools:textColor="@color/train_on_time" />
+
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/cancelled"
-                android:textSize="18sp"
                 android:textColor="@color/train_delayed"
-                android:visibility="@{travelStop.isCancelled ? View.VISIBLE : View.GONE}"/>
+                android:textSize="18sp"
+                android:visibility="@{travelStop.isCancelled ? View.VISIBLE : View.GONE}" />
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/travel_stop_list_item.xml
+++ b/app/src/main/res/layout/travel_stop_list_item.xml
@@ -23,7 +23,7 @@
             android:layout_height="0dp"
             android:scaleType="centerCrop"
             android:src="@drawable/ic_perlschnur_connection"
-            app:layout_constraintBottom_toTopOf="@+id/perlschnur_stop"
+            app:layout_constraintBottom_toTopOf="@id/perlschnur_stop"
             app:layout_constraintEnd_toEndOf="@id/perlschnur_stop"
             app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/travel_stop_list_item.xml
+++ b/app/src/main/res/layout/travel_stop_list_item.xml
@@ -49,7 +49,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/perlschnur_stop"
             app:layout_constraintStart_toStartOf="@id/perlschnur_stop"
-            app:layout_constraintTop_toBottomOf="@+id/perlschnur_stop"
+            app:layout_constraintTop_toBottomOf="@id/perlschnur_stop"
             app:tint="#8A8A8A" />
 
         <TextView


### PR DESCRIPTION
This PR fixes the following issue mentioned in #125:

>  The "Select destination" view items don't expand vertically when the station names are too long, making it hard to read

Now items expand dynamically in height when needed:
![image](https://user-images.githubusercontent.com/8849554/232084956-d0a590b8-b642-4cee-8ac2-5b3b26edf9fa.png)
