### PR TITLE
Do not show a blank profile page if user profile is private

### DIFF
--- a/app/src/main/kotlin/de/hbch/traewelling/navigation/Destinations.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/navigation/Destinations.kt
@@ -55,7 +55,9 @@ fun List<String>.toNavDeepLinks(): List<NavDeepLink> {
 
 @Serializable
 data class PersonalProfile(
-    val username: String? = null
+    val username: String? = null,
+    val isPrivateProfile: Boolean = false,
+    val isFollowing: Boolean = false
 ) : MainDestination {
     override val icon = R.drawable.ic_account
     override val label = R.string.title_user

--- a/app/src/main/kotlin/de/hbch/traewelling/navigation/NavHost.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/navigation/NavHost.kt
@@ -86,9 +86,9 @@ fun TraewelldroidNavHost(
             StatusDetails(statusId)
         )
     }
-    val navToUserProfile: (String) -> Unit = { username ->
+    val navToUserProfile: (String, Boolean, Boolean) -> Unit = { username, isPrivateProfile, isFollowing ->
         navController.navigate(
-            PersonalProfile(username)
+            PersonalProfile(username, isPrivateProfile, isFollowing)
         )
     }
 
@@ -243,6 +243,8 @@ fun TraewelldroidNavHost(
 
             Profile(
                 username = profile.username,
+                isPrivateProfile = profile.isPrivateProfile,
+                isFollowing = profile.isFollowing,
                 loggedInUserViewModel = loggedInUserViewModel,
                 stationSelectedAction = navToSearchConnections,
                 statusSelectedAction = navToStatusDetails,

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/activeCheckins/EnRoute.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/activeCheckins/EnRoute.kt
@@ -26,7 +26,7 @@ import de.hbch.traewelling.util.checkInList
 fun EnRoute(
     loggedInUserViewModel: LoggedInUserViewModel,
     joinConnection: (Status) -> Unit,
-    userSelectedAction: (String) -> Unit = { },
+    userSelectedAction: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     statusSelectedAction: (Int) -> Unit = { },
     statusDeletedAction: () -> Unit = { },
     statusEditAction: (Status) -> Unit = { }

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/dashboard/Dashboard.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/dashboard/Dashboard.kt
@@ -35,7 +35,7 @@ fun Dashboard(
     loggedInUserViewModel: LoggedInUserViewModel,
     joinConnection: (Status) -> Unit,
     searchConnectionsAction: (Int, ZonedDateTime?) -> Unit = { _, _ -> },
-    userSelectedAction: (String) -> Unit = { },
+    userSelectedAction: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     statusSelectedAction: (Int) -> Unit = { },
     statusDeletedAction: () -> Unit = { },
     statusEditAction: (Status) -> Unit = { }
@@ -87,7 +87,7 @@ fun Dashboard(
                     homelandStationData = loggedInUserViewModel.home,
                     recentStationsData = loggedInUserViewModel.lastVisitedStations,
                     onUserSelected = {
-                        userSelectedAction(it.username)
+                        userSelectedAction(it.username, it.privateProfile, it.following)
                     }
                 )
             }

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/include/status/CheckInCard.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/include/status/CheckInCard.kt
@@ -92,7 +92,7 @@ fun CheckInCard(
     loggedInUserViewModel: LoggedInUserViewModel? = null,
     displayLongDate: Boolean = false,
     stationSelected: (Int, ZonedDateTime?) -> Unit = { _, _ -> },
-    userSelected: (String) -> Unit = { },
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     statusSelected: (Int) -> Unit = { },
     handleEditClicked: (Status) -> Unit = { },
     onDeleted: (Status) -> Unit = { }
@@ -359,7 +359,7 @@ fun CheckInCardContent(
     message: Pair<AnnotatedString?, Map<String, InlineTextContent>>,
     operatorCode: String? = null,
     lineId: String? = null,
-    userSelected: (String) -> Unit = { },
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     textClicked: () -> Unit = { }
 ) {
     Column(
@@ -390,7 +390,7 @@ fun CheckInCardContent(
                     onClick = {
                         val annotations = message.first!!.getStringAnnotations(it - 1, it + 1)
                         if (annotations.isNotEmpty()) {
-                            userSelected(annotations.first().item)
+                            userSelected(annotations.first().item, false, false)
                         } else {
                             textClicked()
                         }
@@ -460,7 +460,7 @@ private fun CheckInCardFooter(
     isOwnStatus: Boolean = false,
     displayLongDate: Boolean = false,
     defaultVisibility: StatusVisibility = StatusVisibility.PUBLIC,
-    userSelected: (String) -> Unit = { },
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     handleEditClicked: () -> Unit = { },
     handleDeleteClicked: () -> Unit = { }
 ) {
@@ -582,7 +582,7 @@ private fun CheckInCardFooter(
                 )
                 Text(
                     modifier = alignmentModifier
-                        .clickable { userSelected(status.user.username) }
+                        .clickable { userSelected(status.user.username, false, false) }
                         .padding(2.dp),
                     text = stringResource(
                         id = R.string.check_in_user_time,
@@ -599,7 +599,6 @@ private fun CheckInCardFooter(
                 )
             }
             var menuExpanded by remember { mutableStateOf(false) }
-            val context = LocalContext.current
             Box {
                 Icon(
                     modifier = Modifier

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/statusDetail/StatusDetail.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/statusDetail/StatusDetail.kt
@@ -75,7 +75,7 @@ fun StatusDetail(
     statusDeleted: (Status) -> Unit = { },
     statusEdit: (Status) -> Unit = { },
     loggedInUserViewModel: LoggedInUserViewModel? = null,
-    userSelected: (String) -> Unit = { }
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> }
 ) {
     val statusDetailViewModel: StatusDetailViewModel = viewModel()
     val checkInCardViewModel: CheckInCardViewModel = viewModel()
@@ -296,7 +296,7 @@ private fun StatusLikes(
     likes: Int,
     statusDetailViewModel: StatusDetailViewModel,
     modifier: Modifier = Modifier,
-    userSelected: (String) -> Unit = { }
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> }
 ) {
     var cardExpanded by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
@@ -381,13 +381,13 @@ private fun StatusLikes(
 private fun Liker(
     user: User,
     modifier: Modifier = Modifier,
-    userSelected: (String) -> Unit = { }
+    userSelected: (String, Boolean, Boolean) -> Unit = { _, _, _ -> }
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .clickable { userSelected(user.username) }
+            .clickable { userSelected(user.username, user.privateProfile, user.following) }
             .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {
         Row(

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/user/Profile.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/user/Profile.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,17 +37,19 @@ fun Profile(
     username: String?,
     loggedInUserViewModel: LoggedInUserViewModel,
     joinConnection: (Status) -> Unit,
+    isPrivateProfile: Boolean = false,
+    isFollowing: Boolean = false,
     stationSelectedAction: (Int, ZonedDateTime?) -> Unit = { _, _ -> },
     statusSelectedAction: (Int) -> Unit = { },
     statusDeletedAction: () -> Unit = { },
     statusEditAction: (Status) -> Unit = { },
     dailyStatisticsSelectedAction: (LocalDate) -> Unit = { },
-    userSelectedAction: (String) -> Unit = { },
+    userSelectedAction: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     editProfile: () -> Unit = { },
     manageFollowerAction: () -> Unit = { }
 ) {
     val user = username ?: loggedInUserViewModel.loggedInUser.value?.username
-    var currentPage by remember { mutableStateOf(1) }
+    var currentPage by rememberSaveable { mutableIntStateOf(1) }
     val userStatusViewModel: UserStatusViewModel = viewModel()
     val checkInCardViewModel: CheckInCardViewModel = viewModel()
 
@@ -57,7 +61,7 @@ fun Profile(
         refreshing = refreshing,
         onRefresh = {
             currentPage = 1
-            userStatusViewModel.loadUser(user)
+            userStatusViewModel.loadUser(user, (isPrivateProfile && !isFollowing))
         }
     )
     val listState = rememberLazyListState()
@@ -71,7 +75,7 @@ fun Profile(
 
     LaunchedEffect(Unit) {
         if (!initialized) {
-            userStatusViewModel.loadUser(user)
+            userStatusViewModel.loadUser(user, isPrivateProfile)
             initialized = true
         }
     }

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/user/UserStatusViewModel.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/user/UserStatusViewModel.kt
@@ -3,12 +3,16 @@ package de.hbch.traewelling.ui.user
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import de.hbch.traewelling.api.TraewellingApi
 import de.hbch.traewelling.api.models.Data
 import de.hbch.traewelling.api.models.status.Status
 import de.hbch.traewelling.api.models.status.StatusPage
 import de.hbch.traewelling.api.models.user.User
 import de.hbch.traewelling.logging.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -36,6 +40,15 @@ class UserStatusViewModel : ViewModel() {
                                 resetStatusesForUser(respUser.data.username)
                             }
                             return
+                        } else if (response.code() == 403) {
+                            viewModelScope.launch {
+                                withContext(Dispatchers.Main.immediate) {
+                                    val respUsers = TraewellingApi.userService.searchUsers(username).data
+                                    if (respUsers.isNotEmpty() && respUsers[0].username == username) {
+                                        user.postValue(respUsers[0])
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/app/src/main/kotlin/de/hbch/traewelling/util/Extensions.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/util/Extensions.kt
@@ -90,7 +90,7 @@ fun LazyListScope.checkInList(
     statusSelectedAction: (Int) -> Unit = { },
     statusEditAction: (Status) -> Unit = { },
     statusDeletedAction: () -> Unit = { },
-    userSelectedAction: (String) -> Unit = { },
+    userSelectedAction: (String, Boolean, Boolean) -> Unit = { _, _, _ -> },
     showDailyStatisticsLink: Boolean = false,
     dailyStatisticsSelectedAction: (LocalDate) -> Unit = { },
     showDate: Boolean = true


### PR DESCRIPTION
Right now, if a user that you are not following has a private profile, you are able to find that profile in the search view, but you are unable to see any more information or request to follow that user. Instead you are greeted with a blank profile screen. There are two reasons for this is, the endpoint for retrieving user info returns HTTP 403 for private profiles if you are not following them and non-successful API calls are not handled here, but instead are ignored.

Since the user search method already gives us info on private profiles, I simply added another search call using the username of the user that was selected in the search view, if the user detail endpoint returns the code 403, and use the acquired info to set the user info in the ViewModel. This allows to see some basic info that would also be shown on the web and enables you to request to follow a user with a private profile.

I tried to be as non invasive as possible, so I only added a few lines of code in the ViewModel, but that means my solution requires an additional search call to collect the user info for private profiles. It might be wise to re-iterate on that and save the user info or pass it on when you click on a private profile in the search view to make two API calls less. At least, if you would only pass on the flag that the selected user has a private profile, you could still make one less API call.

Additionally, it might be helpful to add an error or loading indication to the profile screen, if the user is null, that way, if something else goes wrong, at least you do not end up with a blank screen. But that is not covered by this PR as well.

Feel free to make any changes or point me into a specific direction. And even though this might not be the perfect solution yet, I am confident that this small change could make the app slightly better. Cheers