### PR TITLE
:bug: Fix date range for statistics requests

### DIFF
--- a/app/src/main/kotlin/de/hbch/traewelling/api/ApiService.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/api/ApiService.kt
@@ -93,8 +93,8 @@ interface AuthService {
 interface StatisticsService {
     @GET("statistics")
     fun getPersonalStatistics(
-        @Query("from") from: LocalDate,
-        @Query("until") until: LocalDate
+        @Query("from") from: ZonedDateTime,
+        @Query("until") until: ZonedDateTime
     ): Call<Data<PersonalStatistics>>
 
     @GET("statistics/daily/{date}?withPolylines=true")

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/statistics/Statistics.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/statistics/Statistics.kt
@@ -63,8 +63,8 @@ fun Statistics(
         if (range != null) {
             statisticsViewModel.getPersonalStatisticsForSelectedTimeRange()
             dateRangePickerState.setSelection(
-                range.first.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli(),
-                LocalDateTime.of(range.second, LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                range.first.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli(),
+                LocalDateTime.of(range.second, LocalTime.MAX).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
             )
         }
     }

--- a/app/src/main/kotlin/de/hbch/traewelling/ui/statistics/StatisticsViewModel.kt
+++ b/app/src/main/kotlin/de/hbch/traewelling/ui/statistics/StatisticsViewModel.kt
@@ -13,6 +13,7 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.time.LocalDate
+import java.time.ZoneId
 
 class StatisticsViewModel : ViewModel() {
 
@@ -34,8 +35,8 @@ class StatisticsViewModel : ViewModel() {
         val range = dateRange.value ?: initDateRange()
         dateRange.postValue(range)
 
-        val from = range.first
-        val until = range.second
+        val from = range.first.atStartOfDay(ZoneId.systemDefault())
+        val until = range.second.atStartOfDay(ZoneId.systemDefault()).withHour(23).withMinute(59).withSecond(59)
 
         TraewellingApi
             .statisticsService


### PR DESCRIPTION
The date range for statistics requests was not correctly handled, leading to inaccurate results. This commit fixes the issue by:

- Changing the date range parameters in the StatisticsService to use ZonedDateTime instead of LocalDate.
- Updating the StatisticsViewModel to correctly format the date range for the API request.
- Updating the Statistics composable to use UTC for the date range picker.

fixes #266
fixes #268 